### PR TITLE
Update cdnify to error out when local version doesn't match

### DIFF
--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -148,7 +148,7 @@ const npmFetch = async (url) => {
     if (options.npmproxy) {
         opts.agent = new HttpsProxyAgent(options.npmproxy);
     }
-    
+
     // eslint-disable-next-line no-console
     console.info('GET', url);
     return await fetch(url, opts);
@@ -158,7 +158,7 @@ const npmDownload = async (url, dir, filename) => {
     const opts = {};
 
     const host = getHost(url);
-    
+
     if (opts.ipv6) {
         const ip = await dns(host);
         url = url.replace(host, `[${ ip }]`);
@@ -171,7 +171,7 @@ const npmDownload = async (url, dir, filename) => {
     if (options.npmproxy) {
         opts.agent = new HttpsProxyAgent(options.npmproxy);
     }
-    
+
     // eslint-disable-next-line no-console
     console.info('SYNC', url);
     await download(url, dir, opts);
@@ -200,7 +200,14 @@ const info = async (name : string) : Promise<PackageInfo> => {
     if (!json['dist-tags'] || !json['dist-tags'][options.disttag]) {
         throw new Error(`${ options.disttag } dist tag not defined`);
     }
-    
+
+    const localPackage = await getPackage();
+    const publicRegistryVersion = json['dist-tags'][options.disttag];
+
+    if (localPackage.version !== publicRegistryVersion) {
+        throw new Error(`Version mismatch between local package.json (${localPackage.version}) and public npm registry (${ publicRegistryVersion }).`);
+    }
+
     return json;
 };
 
@@ -232,7 +239,7 @@ const cdnifyGenerateModule = async ({ cdnNamespace, name, version }) => {
 
     const cdnModuleDir = join(options.cdnpath, sanitizedName);
     const cdnModuleTarballDir = join(cdnModuleDir, options.tarballfolder);
-        
+
     const cdnModuleInfoFile = join(cdnModuleDir, options.infofile);
     const cdnModuleTarballFileName = `${ version }${ extname(tarball) }`;
 

--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -204,8 +204,8 @@ const info = async (name : string) : Promise<PackageInfo> => {
     const localPackage = await getPackage();
     const publicRegistryVersion = json['dist-tags'][options.disttag];
 
-    if (localPackage.version !== publicRegistryVersion) {
-        throw new Error(`Version mismatch between local package.json (${localPackage.version}) and public npm registry (${ publicRegistryVersion }).`);
+    if (options.disttag === 'latest' && localPackage.version !== publicRegistryVersion) {
+        throw new Error(`Version mismatch between local package.json (${ localPackage.version }) and public npm registry (${ publicRegistryVersion }).`);
     }
 
     return json;


### PR DESCRIPTION
Sometimes the `cdnify` step does not pick up the most recent version. This PR throws an error when the local version doesn't match the version returned by the npm registry. 

This version check only happens for the `latest` dist tag use case. The thinking here is rollback scenarios will still work fine if we want to deploy an older version for another dist tag like `active-production`.

Here's an example of this error being thrown:

<img width="1083" alt="Screen Shot 2020-10-07 at 11 15 41 AM" src="https://user-images.githubusercontent.com/534034/95359218-83d43480-088f-11eb-8fcd-192ca9ff75e2.png">