### PR TITLE
Use fetch-retry to deal with ECONNRESET errors with cdnify()

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "readmeFilename": "README.md",
   "dependencies": {
+    "@vercel/fetch-retry": "^5.0.3",
     "check-node-version": "^4.0.3",
     "command-line-args": "^5.1.1",
     "download": "^8.0.0",

--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -8,13 +8,18 @@ import { userInfo } from 'os';
 import { lookup } from 'dns';
 
 import config from 'libnpmconfig';
-import fetch from 'node-fetch';
+import nodeFetch from 'node-fetch';
+import fetchRetry from '@vercel/fetch-retry';
 import { ensureDir, outputFile, exists, remove, existsSync, readFileSync } from 'fs-extra';
 import download from 'download';
 import commandLineArgs from 'command-line-args';
 import { prompt } from 'inquirer';
 import HttpsProxyAgent from 'https-proxy-agent';
 import shell from 'shelljs';
+
+// use fetch() with retry logic to prevent failing from ECONNRESET errors
+// https://github.com/vercel/fetch-retry#rationale
+const fetch = fetchRetry(nodeFetch);
 
 type Package = {|
     name : string,


### PR DESCRIPTION
We have been seeing ECONNRESET errors when using grabthar-cdnify most likely caused by the corporate proxy.

![image](https://user-images.githubusercontent.com/534034/121088921-0c52fe00-c7ac-11eb-95f7-e013441f40b9.png)

The sync process with cdnify can make many calls to the npm registry so having retry behavior seems like an easy solve. This PR adds the fetch-retry module to handle this for us: https://github.com/vercel/fetch-retry#rationale