### PR TITLE
Add retry logic for `npm run upgrade` to help cope with intermittent ECONNRESET errors

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -9,24 +9,27 @@ attempt=1
 max_attempts=5
 failure_message="npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
 
-until [ $attempt -eq $((max_attempts+1)) ]
-do
-    if [ -z "$1" ]; then
+if [ -z "$1" ]; then
+    until [ $attempt -eq $((max_attempts+1)) ]
+    do
         printf "npm-check-updates attempt $attempt of $max_attempts\n"
         npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade && break
         if [ $attempt -eq $max_attempts ]; then
             printf "$failure_message"
         fi;
         attempt=$((attempt+1))
-    else
+    done
+else
+    until [ $attempt -eq $((max_attempts+1)) ]
+    do
         printf "npm-check-updates attempt $attempt of $max_attempts\n"
         npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade --filter="$1" && break
         if [ $attempt -eq $max_attempts ]; then
             printf "$failure_message"
         fi;
         attempt=$((attempt+1))
-    fi;
-done
+    done
+fi;
 
 rm -rf ./node_modules;
 rm -f ./package-lock.json;

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -5,11 +5,27 @@ set -e;
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 $DIR/grabthar-validate-git;
 
-if [ -z "$1" ]; then
-    npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade
-else
-    npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade --filter="$1"
-fi;
+attempt=1
+max_attempts=5
+
+until [ $attempt -eq $((max_attempts+1)) ]
+do
+    if [ -z "$1" ]; then
+        printf "npm-check-updates attempt $attempt of $max_attempts\n"
+        npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade && break
+        if [ $attempt -eq $max_attempts ]; then
+            printf "npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
+        fi;
+        attempt=$((attempt+1))
+    else
+        printf "npm-check-updates attempt $attempt of $max_attempts\n"
+        npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade --filter="$1" && break
+        if [ $attempt -eq $max_attempts ]; then
+            printf "npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
+        fi;
+        attempt=$((attempt+1))
+    fi;
+done
 
 rm -rf ./node_modules;
 rm -f ./package-lock.json;

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -7,6 +7,7 @@ $DIR/grabthar-validate-git;
 
 attempt=1
 max_attempts=5
+failure_message="npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
 
 until [ $attempt -eq $((max_attempts+1)) ]
 do
@@ -14,14 +15,14 @@ do
         printf "npm-check-updates attempt $attempt of $max_attempts\n"
         npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade && break
         if [ $attempt -eq $max_attempts ]; then
-            printf "npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
+            printf "$failure_message"
         fi;
         attempt=$((attempt+1))
     else
         printf "npm-check-updates attempt $attempt of $max_attempts\n"
         npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade --filter="$1" && break
         if [ $attempt -eq $max_attempts ]; then
-            printf "npm-check-updates failed after $max_attempts attempts. Please try running npm run upgrade again.\n"
+            printf "$failure_message"
         fi;
         attempt=$((attempt+1))
     fi;


### PR DESCRIPTION
### Purpose

This PR adds retry logic to help cope with intermittent ECONNRESET errors when running `npm run upgrade` in paypal-sdk-release.

Here is an example error:

![Screen Shot 2021-06-16 at 12 26 43 PM](https://user-images.githubusercontent.com/20399044/122453568-217c1980-cf70-11eb-806d-a3016c069e06.png)

The retry logic will attempt to run `npm-check-updates` five times before exiting, but can be easily increased/decreased.