### PR TITLE
Update release script to update non-prod dist tags

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -20,6 +20,10 @@ if [ -z "$version" ]; then
     version=$(npm view $module version);
 fi;
 
+if [ -z "$CDNIFY" ]; then
+    CDNIFY=true
+fi;
+
 if [ -z "$2" ]; then
     envs="$defenvs"
 else
@@ -44,4 +48,6 @@ for env in $envs; do
     $DIR/grabthar-verify-npm-publish "$version" "$tag-$env";
 done;
 
-$DIR/grabthar-cdnify
+if [ "$CDNIFY" = true ]; then
+    $DIR/grabthar-cdnify
+fi;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,5 +29,5 @@ $DIR/grabthar-verify-npm-publish $local_version $DIST_TAG
 
 # update non-prod dist tags whenever the latest dist tag changes
 if [ "$DIST_TAG" = "latest" ]; then
-    $DIR/grabthar-activate $local_version "test local stage"
+    CDNIFY=false $DIR/grabthar-activate $local_version "test local stage"
 fi;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,3 +26,8 @@ local_version=$(node --eval "
 ")
 
 $DIR/grabthar-verify-npm-publish $local_version $DIST_TAG
+
+# update non-prod dist tags whenever the latest dist tag changes
+if [ "$DIST_TAG" = "latest" ]; then
+    $DIR/grabthar-activate $local_version "test local stage"
+fi;


### PR DESCRIPTION
This PR updates `grabthar-release` to update all non-prod dist tags to match whenever the "latest" dist tag is changed. It does so by adding a new `CDNIFY` environment variable option for `grabthar-activate` that can disable the cdnify step so it can be reused in `grabthar-release` for activating the non-prod dist tags.

The release process for SPB and the JS SDK involves manually updating non-prod dist-tags like `active-stage` with the first bundle so we can better validate in stage before shipping the second bundle to prod. This PR automates this manual step.
