### PR TITLE
Add npm token check for 2FA prompt & npm publish

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -37,7 +37,13 @@ else
     done;
 fi;
 
+IS_NPM_OTP=false
+
 if [ -z "$NPM_TOKEN" ]; then
+    IS_NPM_OTP=true
+fi;
+
+if [ "$IS_NPM_OTP" = true ]; then
     read -p "NPM 2FA Code: " twofactorcode
 fi;
 

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -48,8 +48,13 @@ if [ "$IS_NPM_OTP" = true ]; then
 fi;
 
 for env in $envs; do
-    echo npm dist-tag add $module@$version "$tag-$env" --otp="$twofactorcode";
-    npm dist-tag add $module@$version "$tag-$env" --otp="$twofactorcode";
+    if [ "$IS_NPM_OTP" = true ]; then
+        echo npm dist-tag add $module@$version "$tag-$env" --otp="$twofactorcode";
+        npm dist-tag add $module@$version "$tag-$env" --otp="$twofactorcode";
+    else
+        echo npm dist-tag add $module@$version "$tag-$env"
+        NPM_TOKEN=$NPM_TOKEN npm dist-tag add $module@$version "$tag-$env"
+    fi;
 done;
 
 for env in $envs; do

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -37,7 +37,9 @@ else
     done;
 fi;
 
-read -p "NPM 2FA Code: " twofactorcode
+if [ -z "$NPM_TOKEN" ]; then
+    read -p "NPM 2FA Code: " twofactorcode
+fi;
 
 for env in $envs; do
     echo npm dist-tag add $module@$version "$tag-$env" --otp="$twofactorcode";

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,7 @@ npm version ${1-patch};
 git push;
 git push --tags;
 $DIR/grabthar-flatten;
-npm publish --tag $DIST_TAG;
+NPM_TOKEN=$NPM_TOKEN npm publish --tag $DIST_TAG;
 git checkout package.json;
 git checkout package-lock.json || echo 'Package lock not found';
 


### PR DESCRIPTION
### Purpose

This PR checks for an npm token. If one exists, it does not prompt for the 2FA, and passes it to `npm publish`.