### PR TITLE
The commitonly cdnify option should not prompt for confirmation

### DIFF
--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -464,10 +464,6 @@ const run = async () => {
     await cdnifyGenerate(options.module);
 
     if (options.commitonly) {
-        if (!await getYesNo('Commit changes?')) {
-            return;
-        }
-
         return await cdnifyCommit();
     }
 


### PR DESCRIPTION
The plan is to use `npm run cdnify --commitonly` from CI for updating the cdn folder in sdk-release and SPB.