### PR TITLE
Update npm repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/krakenjs/grumbler.git"
+    "url": "git://github.com/krakenjs/grabthar-release.git"
   },
   "keywords": [
     "template"


### PR DESCRIPTION
### Description

This PR updates the npm repo url, which is currently pointing to grumbler:

![Screen Shot 2022-01-27 at 3 21 13 PM](https://user-images.githubusercontent.com/20399044/151453306-35ce1ab8-0b8d-4577-826e-91188d11ee45.png)