### PR TITLE
Fix unstaged/uncommitted changes error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: Publish to npm
-        run: npm run publish
+        run: npm run publish-npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global user.name ${{ github.actor }}
 
       - name: Publish to npm
-        run: npm run publish-npm
+        run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "npm run babel",
     "postpublish": "git checkout ./scripts",
     "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
-    "publish-npm": "./publish.mjs"
+    "release": "./publish.mjs"
   },
   "bin": {
     "grabthar-activate": "./scripts/activate.mjs",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint scripts/ --ext .js,.mjs",
     "flow": "flow check",
     "test": "npm run lint && npm run flow-typed && npm run flow",
-    "babel": "babel scripts --ignore=node_modules --out-dir scripts --source-maps inline",
+    "babel": "babel scripts --ignore=node_modules,scripts/*.mjs --out-dir scripts --source-maps inline",
     "prepublishOnly": "npm run babel",
     "postpublish": "git checkout ./scripts",
     "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepublishOnly": "npm run babel",
     "postpublish": "git checkout ./scripts",
     "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
-    "publish": "./publish.mjs"
+    "publish-npm": "./publish.mjs"
   },
   "bin": {
     "grabthar-activate": "./scripts/activate.mjs",


### PR DESCRIPTION
### Purpose

This PR fixes an `Cannot continue with unstaged or uncommitted changes` error that was caused by accidentally running `publish.mjs` twice by using a `publish` command in the `package.json` file. It also ignores `.mjs` files during `npm run babel`.