### PR TITLE
Fix `publish` GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: 📥 Download deps
-        run: npm run reinstall
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
 
       - name: Configure git user
         run: |


### PR DESCRIPTION
### Purpose

This PR uses `bahmutov/npm-install@v1` in the `publish` GitHub Actions workflow, instead of running the non-existent `npm run reinstall` command.