### PR TITLE
Trim newline

### DIFF
--- a/scripts/verify-npm-publish.mjs
+++ b/scripts/verify-npm-publish.mjs
@@ -41,6 +41,7 @@ while (LOCAL_VERSION !== npm_public_registry_version) {
     console.log(`Version mismatch between local version ${ LOCAL_VERSION } and npm version ${ npm_public_registry_version }. Trying again in ${ interval } seconds...`);
     await $`sleep ${ interval }`;
     npm_public_registry_version = await $`npm view ${ PACKAGE_NAME } dist-tags.${ DIST_TAG }`;
+    npm_public_registry_version = npm_public_registry_version.trim();
     counter += interval;
 }
 


### PR DESCRIPTION
### Purpose

This PR removes a newline character when updating `npm_public_registry_version`. Without this, `LOCAL_VERSION !== npm_public_registry_version` will continue to return `true`, and the `while` loop will eventually time out.