### PR TITLE
Auto select dist-tag and version, and block publishing from forks

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -28,11 +28,9 @@ await $`grabthar-validate-npm`;
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    await $`npm version ${ BUMP }`;
-} else {
-    await $`npm version ${ BUMP }`;
 }
 
+await $`npm version ${ BUMP }`;
 await $`git push`;
 await $`git push --tags`;
 await $`grabthar-flatten`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,7 +15,7 @@ let twoFactorCode;
 
 NPM_TOKEN = NPM_TOKEN || '';
 
-// The type of release will be based on the current git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
+// This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
 let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
 CURRENT_BRANCH = CURRENT_BRANCH.trim();

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,6 +15,8 @@ let twoFactorCode;
 
 NPM_TOKEN = NPM_TOKEN || '';
 
+// The type of release will be based on the current git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
+
 let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
 CURRENT_BRANCH = CURRENT_BRANCH.trim();
 let { stdout: DEFAULT_BRANCH } = await $`git remote show origin | sed -n '/HEAD branch/s/.*: //p'`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,12 +8,23 @@ import { $, question } from 'zx';
 
 const moduleMetaUrl = import.meta.url;
 const require = createRequire(moduleMetaUrl);
+
 let { NPM_TOKEN } = env;
+NPM_TOKEN = NPM_TOKEN || '';
+
 let BUMP = 'patch';
 let DIST_TAG = 'latest';
 let twoFactorCode;
 
-NPM_TOKEN = NPM_TOKEN || '';
+let { stdout: REMOTE_URL } = await $`git config --get remote.origin.url`;
+REMOTE_URL = REMOTE_URL.trim();
+
+const CWD = cwd();
+const { version: LOCAL_VERSION, repository: { url: REPO_URL } } = require(`${ CWD }/package.json`);
+
+if (REMOTE_URL !== REPO_URL) {
+    throw new Error('The remote url does not match the repo url. Publishing from a fork is not allowed.');
+}
 
 // This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
@@ -44,10 +55,6 @@ if (NPM_TOKEN) {
 
 await $`git checkout package.json`;
 await $`git checkout package-lock.json || echo 'Package lock not found'`;
-
-const CWD = cwd();
-const { version: LOCAL_VERSION } = require(`${ CWD }/package.json`);
-
 await $`grabthar-verify-npm-publish --LOCAL_VERSION=${ LOCAL_VERSION } --DIST_TAG=${ DIST_TAG }`;
 
 // update non-prod dist tags whenever the latest dist tag changes

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -42,15 +42,15 @@ if (fork) {
     throw new Error('Publishing from a fork is not allowed.');
 }
 
+await $`grabthar-validate-git`;
+await $`grabthar-validate-npm`;
+
 // This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
 let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
 CURRENT_BRANCH = CURRENT_BRANCH.trim();
 let { stdout: DEFAULT_BRANCH } = await $`git remote show origin | sed -n '/HEAD branch/s/.*: //p'`;
 DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
-
-await $`grabthar-validate-git`;
-await $`grabthar-validate-npm`;
 
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -22,7 +22,15 @@ DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
 
 await $`grabthar-validate-git`;
 await $`grabthar-validate-npm`;
-await $`npm version ${ BUMP }`;
+
+if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
+    BUMP = 'prerelease';
+    DIST_TAG = 'alpha';
+    await $`npm version ${ BUMP }`;
+} else {
+    await $`npm version ${ BUMP }`;
+}
+
 await $`git push`;
 await $`git push --tags`;
 await $`grabthar-flatten`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -16,9 +16,6 @@ let BUMP = 'patch';
 let DIST_TAG = 'latest';
 let twoFactorCode;
 
-const CWD = cwd();
-const { version: LOCAL_VERSION } = require(`${ CWD }/package.json`);
-
 let { stdout: REMOTE_URL } = await $`git config --get remote.origin.url`;
 REMOTE_URL = REMOTE_URL.trim();
 
@@ -72,6 +69,10 @@ if (NPM_TOKEN) {
 
 await $`git checkout package.json`;
 await $`git checkout package-lock.json || echo 'Package lock not found'`;
+
+const CWD = cwd();
+const { version: LOCAL_VERSION } = require(`${ CWD }/package.json`);
+
 await $`grabthar-verify-npm-publish --LOCAL_VERSION=${ LOCAL_VERSION } --DIST_TAG=${ DIST_TAG }`;
 
 // update non-prod dist tags whenever the latest dist tag changes

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -33,12 +33,13 @@ const isForked = async () => {
     if (jsonData.message === 'Not Found') {
         throw new Error('Repo not found via the GitHub Repos API.');
     }
-    return jsonData;
+    const { fork } = jsonData;
+    return fork;
 };
 
-const { fork } = await isForked();
+const forked = await isForked();
 
-if (fork) {
+if (forked) {
     throw new Error('Publishing from a fork is not allowed.');
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,6 +15,11 @@ let twoFactorCode;
 
 NPM_TOKEN = NPM_TOKEN || '';
 
+let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
+CURRENT_BRANCH = CURRENT_BRANCH.trim();
+let { stdout: DEFAULT_BRANCH } = await $`git remote show origin | sed -n '/HEAD branch/s/.*: //p'`;
+DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
+
 await $`grabthar-validate-git`;
 await $`grabthar-validate-npm`;
 await $`npm version ${ BUMP }`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -4,16 +4,15 @@
 import { cwd, env } from 'process';
 import { createRequire } from 'module';
 
-import { $, argv, question } from 'zx';
+import { $, question } from 'zx';
 
 const moduleMetaUrl = import.meta.url;
 const require = createRequire(moduleMetaUrl);
 let { NPM_TOKEN } = env;
-let { DIST_TAG, BUMP } = argv;
+let BUMP = 'patch';
+let DIST_TAG = 'latest';
 let twoFactorCode;
 
-DIST_TAG = DIST_TAG || 'latest';
-BUMP = BUMP || 'patch';
 NPM_TOKEN = NPM_TOKEN || '';
 
 await $`grabthar-validate-git`;


### PR DESCRIPTION
### Purpose

Instead of having to run separate commands or workflows for `latest` or `alpha` releases, this PR allows us to simply run a single command either locally or via GitHub Actions (i.e. `npm run release`). The type of release will be determined by which branch one is on. The default branch will yield a `patch` release on `latest`, and any other branch will yield a `prerelease` release on `alpha`. Forked repos will be blocked from publishing.