### PR TITLE
Remove `--no-git-tag-version` from `alpha` releases

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -53,7 +53,7 @@ DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    await $`npm --no-git-tag-version version ${ BUMP } --preid=${ DIST_TAG }`;
+    await $`npm version ${ BUMP } --preid=${ DIST_TAG }`;
 } else {
     await $`npm version ${ BUMP }`;
 }


### PR DESCRIPTION
### Purpose

Unfortunately, using the `--no-git-tag-version` option for `npm version` during `alpha` releases leaves unstaged/uncommitted changes in source control, which causes `grabthar-flatten` -> `grabthar-validate-git` to fail prior to publishing. This PR removes `--no-git-tag-version`.

Another idea would be to keep `--no-git-tag-version` and run `git stash`, `grabthar-flatten`, then `git stash apply` for `alpha` releases: https://github.com/krakenjs/grabthar-release/pull/30

<img width="1536" alt="Screen Shot 2022-03-22 at 4 17 52 PM" src="https://user-images.githubusercontent.com/20399044/159591819-d53b7001-06fb-4ab2-ae8f-1e0b577c1d15.png">