### PR TITLE
Stash `version` change before running `flatten` for `alpha` releases

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -62,9 +62,12 @@ await $`git push`;
 
 if (DIST_TAG === 'latest') {
     await $`git push --tags`;
+    await $`grabthar-flatten`;
+} else {
+    await $`git stash`;
+    await $`grabthar-flatten`;
+    await $`git stash apply`;
 }
-
-await $`grabthar-flatten`;
 
 if (NPM_TOKEN) {
     await $`NPM_TOKEN=${ NPM_TOKEN } npm publish --tag ${ DIST_TAG }`;


### PR DESCRIPTION
### Purpose

Unfortunately, using the `--no-git-tag-version` option for `npm version` during `alpha` releases leaves unstaged/uncommitted changes in source control, which causes `grabthar-flatten` -> `grabthar-validate-git` to fail prior to publishing.

As an alternative to [removing `--no-git-tag-version` from `alpha` releases](https://github.com/krakenjs/grabthar-release/pull/28), we could stash the `version` change prior to running `grabthar-flatten`, then reapply it after `grabthar-flatten` finishes.