### PR TITLE
Revert `--no-git-tag-version` changes

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -53,7 +53,7 @@ DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    await $`npm --no-git-tag-version version ${ BUMP } --preid=${ DIST_TAG }`;
+    await $`npm version ${ BUMP } --preid=${ DIST_TAG }`;
 } else {
     await $`npm version ${ BUMP }`;
 }
@@ -62,12 +62,9 @@ await $`git push`;
 
 if (DIST_TAG === 'latest') {
     await $`git push --tags`;
-    await $`grabthar-flatten`;
-} else {
-    await $`git stash`;
-    await $`grabthar-flatten`;
-    await $`git stash apply`;
 }
+
+await $`grabthar-flatten`;
 
 if (NPM_TOKEN) {
     await $`NPM_TOKEN=${ NPM_TOKEN } npm publish --tag ${ DIST_TAG }`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -59,11 +59,7 @@ if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
 }
 
 await $`git push`;
-
-if (DIST_TAG === 'latest') {
-    await $`git push --tags`;
-}
-
+await $`git push --tags`;
 await $`grabthar-flatten`;
 
 if (NPM_TOKEN) {


### PR DESCRIPTION
### Purpose

This PR reverts the `--no-git-tag-version` changes that were made for `alpha` releases, because we lose the uncommitted version change in `package.json` prior to running `grabthar-verify-npm-publish` in two places:

1. https://github.com/paypal/paypal-smart-payment-buttons/blob/main/package.json#L64
2. https://github.com/krakenjs/grabthar-release/blob/main/scripts/release.mjs#L79

Additionally, the original aim was not to push any commits to one's feature branch during `alpha` releases, however, this is negated by the `Dist` commit here anyway:

1. https://github.com/paypal/paypal-smart-payment-buttons/blob/main/package.json#L48