### PR TITLE
fix: run babel before and check out `scripts` after publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "babel": "babel scripts --ignore=node_modules,scripts/*.mjs --out-dir scripts --source-maps inline",
     "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
     "prepare": "husky install",
-    "prerelease": "npm run babel",
+    "prepublishOnly": "npm run babel",
     "release": "standard-version",
     "postrelease": "git push && git push --follow-tags && npm publish && git checkout ./scripts"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "prerelease": "npm run babel",
     "release": "standard-version",
-    "postrelease": "git checkout ./scripts && git push && git push --follow-tags && npm publish"
+    "postrelease": "git push && git push --follow-tags && npm publish && git checkout ./scripts"
   },
   "bin": {
     "grabthar-activate": "./scripts/activate.mjs",


### PR DESCRIPTION
### Purpose

This PR runs `git checkout ./scripts` after pushing and publishing, so as to avoid wiping out the output of `npm run babel` before publishing.