### PR TITLE
feat: add dry run option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krakenjs/grabthar-release",
-  "version": "2.1.7-alpha-eb7bb1bc.0",
+  "version": "2.1.6",
   "description": "Helper scripts for grabthar releases.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krakenjs/grabthar-release",
-  "version": "2.1.6",
+  "version": "2.1.7-alpha-eb7bb1bc.0",
   "description": "Helper scripts for grabthar releases.",
   "main": "index.js",
   "scripts": {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -66,6 +66,10 @@ if (!DRY_RUN) {
     await $`git push`;
     await $`git push --tags`;
     await $`grabthar-flatten`;
+} else {
+    console.log(`git push`);
+    console.log(`git push --tags`);
+    console.log(`grabthar-flatten`);
 }
 
 if (NPM_TOKEN) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -57,17 +57,9 @@ const UID = crypto.randomBytes(4).toString('hex');
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    if (!DRY_RUN) {
-        await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
-    } else {
-        console.log(`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`);
-    }
+    await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
 } else {
-    if (!DRY_RUN) {
-        await $`npm version ${ BUMP }`;
-    } else {
-        console.log(`npm version ${ BUMP }`);
-    }
+    await $`npm version ${ BUMP }`;
 }
 
 if (!DRY_RUN) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -70,12 +70,12 @@ if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
 if (DRY_RUN) {
     console.log(`git push`);
     console.log(`git push --tags`);
-    await $`grabthar-flatten`;
 } else {
     await $`git push`;
     await $`git push --tags`;
-    await $`grabthar-flatten`;
 }
+
+await $`grabthar-flatten`;
 
 if (NPM_TOKEN) {
     await $`NPM_TOKEN=${ NPM_TOKEN } npm publish ${ dryRun } --tag ${ DIST_TAG }`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -14,7 +14,7 @@ let { NPM_TOKEN } = env;
 NPM_TOKEN = NPM_TOKEN || '';
 
 let { DRY_RUN } = argv;
-DRY_RUN = DRY_RUN === 'true' ? true : false;
+DRY_RUN = DRY_RUN === 'true';
 
 const noGitTag = DRY_RUN ? '--no-git-tag-version' : '';
 const dryRun = DRY_RUN ? '--dry-run' : '';

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -57,9 +57,17 @@ const UID = crypto.randomBytes(4).toString('hex');
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
+    if (!DRY_RUN){
+        await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
+    } else {
+        await $`npm --no-git-tag-version version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
+    }
 } else {
-    await $`npm version ${ BUMP }`;
+    if (!DRY_RUN) {
+        await $`npm version ${ BUMP }`;
+    } else {
+        await $`npm --no-git-tag-version version ${ BUMP }`;
+    }
 }
 
 if (!DRY_RUN) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -100,4 +100,16 @@ if (!DRY_RUN) {
     if (DIST_TAG === 'latest') {
         await $`grabthar-activate --LOCAL_VERSION=${ LOCAL_VERSION } --CDNIFY=false --ENVS=test,local,stage`;
     }
+} else {
+    const CWD = cwd();
+    const { version: LOCAL_VERSION } = require(`${ CWD }/package.json`);
+
+    console.log(`grabthar-verify-npm-publish --LOCAL_VERSION=${ LOCAL_VERSION } --DIST_TAG=${ DIST_TAG }`);
+
+    if (DIST_TAG === 'latest') {
+        console.log(`grabthar-activate --LOCAL_VERSION=${ LOCAL_VERSION } --CDNIFY=false --ENVS=test,local,stage`);
+    }
+
+    await $`git checkout package.json`;
+    await $`git checkout package-lock.json || echo 'Package lock not found'`;
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -77,7 +77,7 @@ if (!DRY_RUN) {
 } else {
     console.log(`git push`);
     console.log(`git push --tags`);
-    console.log(`grabthar-flatten`);
+    await $`grabthar-flatten`;
 }
 
 if (NPM_TOKEN) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -57,7 +57,7 @@ const UID = crypto.randomBytes(4).toString('hex');
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    if (!DRY_RUN){
+    if (!DRY_RUN) {
         await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
     } else {
         await $`npm --no-git-tag-version version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -16,6 +16,9 @@ NPM_TOKEN = NPM_TOKEN || '';
 let { DRY_RUN } = argv;
 DRY_RUN = DRY_RUN === 'true' ? true : false;
 
+const noGitTag = DRY_RUN ? '--no-git-tag-version' : '';
+const dryRun = DRY_RUN ? '--dry-run' : '';
+
 let BUMP = 'patch';
 let DIST_TAG = 'latest';
 let twoFactorCode;
@@ -59,17 +62,9 @@ const UID = crypto.randomBytes(4).toString('hex');
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
     BUMP = 'prerelease';
     DIST_TAG = 'alpha';
-    if (DRY_RUN) {
-        await $`npm --no-git-tag-version version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
-    } else {
-        await $`npm version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
-    }
+    await $`npm ${ noGitTag } version ${ BUMP } --preid=${ DIST_TAG }-${ UID }`;
 } else {
-    if (DRY_RUN) {
-        await $`npm --no-git-tag-version version ${ BUMP }`;
-    } else {
-        await $`npm version ${ BUMP }`;
-    }
+    await $`npm ${ noGitTag } version ${ BUMP }`;
 }
 
 if (DRY_RUN) {
@@ -83,18 +78,10 @@ if (DRY_RUN) {
 }
 
 if (NPM_TOKEN) {
-    if (DRY_RUN) {
-        await $`NPM_TOKEN=${ NPM_TOKEN } npm publish --dry-run --tag ${ DIST_TAG }`;
-    } else {
-        await $`NPM_TOKEN=${ NPM_TOKEN } npm publish --tag ${ DIST_TAG }`;
-    }
+    await $`NPM_TOKEN=${ NPM_TOKEN } npm publish ${ dryRun } --tag ${ DIST_TAG }`;
 } else {
     twoFactorCode = await question('NPM 2FA Code: ');
-    if (DRY_RUN) {
-        await $`npm publish --dry-run --tag ${ DIST_TAG } --otp ${ twoFactorCode }`;
-    } else {
-        await $`npm publish --tag ${ DIST_TAG } --otp ${ twoFactorCode }`;
-    }
+    await $`npm publish ${ dryRun } --tag ${ DIST_TAG } --otp ${ twoFactorCode }`;
 }
 
 if (DRY_RUN) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,14 +5,16 @@ import { cwd, env } from 'process';
 import { createRequire } from 'module';
 import crypto from 'crypto';
 
-import { $, question, fetch } from 'zx';
+import { $, question, fetch, argv } from 'zx';
 
 const moduleMetaUrl = import.meta.url;
 const require = createRequire(moduleMetaUrl);
 
-let { NPM_TOKEN, DRY_RUN } = env;
+let { NPM_TOKEN } = env;
 NPM_TOKEN = NPM_TOKEN || '';
-DRY_RUN = DRY_RUN || false;
+
+let { DRY_RUN } = argv;
+DRY_RUN = DRY_RUN === 'true' ? true : false;
 
 let BUMP = 'patch';
 let DIST_TAG = 'latest';

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -109,7 +109,6 @@ if (DRY_RUN) {
 
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;
-    await $`git checkout ./scripts`;
 } else {
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -120,4 +120,5 @@ if (!DRY_RUN) {
 
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;
+    await $`git checkout ./scripts`;
 }


### PR DESCRIPTION
### Purpose

This PR adds a dry run feature to show what would've happened while publishing an npm package without actually pushing anything to GitHub or publishing anything to npm. It logs any steps that aren't run for a better view of the complete process. It also reverts any changes to the `package.json` and `package-lock.json` files when done, so no manual cleanup is required. 

I've added local and CI support for this in **paypal-smart-payment-buttons** and **paypal-sdk-release**:

- https://github.com/paypal/paypal-smart-payment-buttons/pull/372
- https://github.com/paypal/paypal-sdk-release/pull/41

Here is an example screenshot of what it looks like:

<img width="413" alt="Screen Shot 2022-04-05 at 11 47 08 AM" src="https://user-images.githubusercontent.com/20399044/162018513-ab9daefb-cbd6-4ba1-aabb-873dd1e58040.png">
