### PR TITLE
fix: get `DRY_RUN` from `env` and do final cleanup

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -94,7 +94,7 @@ if (DRY_RUN) {
 
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;
-    await $`git checkout .`;
+    await $`git clean -f && git checkout .`;
 } else {
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -94,6 +94,7 @@ if (DRY_RUN) {
 
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;
+    await $`git checkout .`;
 } else {
     await $`git checkout package.json`;
     await $`git checkout package-lock.json || echo 'Package lock not found'`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,15 +5,13 @@ import { cwd, env } from 'process';
 import { createRequire } from 'module';
 import crypto from 'crypto';
 
-import { $, question, fetch, argv } from 'zx';
+import { $, question, fetch } from 'zx';
 
 const moduleMetaUrl = import.meta.url;
 const require = createRequire(moduleMetaUrl);
 
-let { NPM_TOKEN } = env;
+let { NPM_TOKEN, DRY_RUN } = env;
 NPM_TOKEN = NPM_TOKEN || '';
-
-let { DRY_RUN } = argv;
 DRY_RUN = DRY_RUN === 'true';
 
 const noGitTag = DRY_RUN ? '--no-git-tag-version' : '';


### PR DESCRIPTION
### Purpose

SPB uses [postpublish](https://github.com/paypal/paypal-smart-payment-buttons/blob/main/package.json#L63) to clean up after babel. Normally this is fine, but it wipes out our version bump during dry-runs:

![Screen Shot 2022-04-07 at 12 26 50 PM](https://user-images.githubusercontent.com/20399044/162283498-1130458a-b837-418c-b86f-3fc430f52353.png)

This PR lays the groundwork for fixing this issue by getting `DRY_RUN` from `env`, and providing our own all-encompassing cleanup via `git clean -f && git checkout .`. Once an `if` condition using `DRY_RUN` has been added to `postpublish` in SPB, we will see the correct output during dry-runs: 

![Screen Shot 2022-04-07 at 12 25 57 PM](https://user-images.githubusercontent.com/20399044/162283849-619bcab4-1562-4cf2-bd76-20cccaf2e3e2.png)
