### PR TITLE
fix: access `stdout` property before `trim()`

### DIFF
--- a/scripts/verify-npm-publish.mjs
+++ b/scripts/verify-npm-publish.mjs
@@ -41,8 +41,7 @@ while (LOCAL_VERSION !== npm_public_registry_version) {
     console.log(`Version mismatch between local version ${ LOCAL_VERSION } and npm version ${ npm_public_registry_version }. Trying again in ${ interval } seconds...`);
     await $`sleep ${ interval }`;
     npm_public_registry_version = await $`npm view ${ PACKAGE_NAME } dist-tags.${ DIST_TAG }`;
-    npm_public_registry_version = npm_public_registry_version.stdout;
-    npm_public_registry_version = npm_public_registry_version.trim();
+    npm_public_registry_version = npm_public_registry_version.stdout.trim();
     counter += interval;
 }
 

--- a/scripts/verify-npm-publish.mjs
+++ b/scripts/verify-npm-publish.mjs
@@ -41,6 +41,7 @@ while (LOCAL_VERSION !== npm_public_registry_version) {
     console.log(`Version mismatch between local version ${ LOCAL_VERSION } and npm version ${ npm_public_registry_version }. Trying again in ${ interval } seconds...`);
     await $`sleep ${ interval }`;
     npm_public_registry_version = await $`npm view ${ PACKAGE_NAME } dist-tags.${ DIST_TAG }`;
+    npm_public_registry_version = npm_public_registry_version.stdout;
     npm_public_registry_version = npm_public_registry_version.trim();
     counter += interval;
 }


### PR DESCRIPTION
### Purpose

Currently, if `npm_public_registry_version` does not immediately match `LOCAL_VERSION`, trimming the newline during the next reassignment of `npm_public_registry_version` will fail, because `trim()` is being called on an object. This can be fixed by accessing the `stdout` property of `npm_public_registry_version` before calling `trim()`. Here is a screenshot of the error before the fix:

<img width="844" alt="Screen Shot 2022-04-11 at 2 16 07 PM" src="https://user-images.githubusercontent.com/20399044/162834767-c5d52f88-f46c-4c0e-baf4-c7cdbd559289.png">
