### PR TITLE
feat: cleanup previous verisoned folders

### DIFF
--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -5,6 +5,7 @@
 
 import { join, extname } from 'path';
 import { userInfo } from 'os';
+import { promises as fs  } from 'fs';
 
 import nodeFetch from 'node-fetch';
 import fetchRetry from '@vercel/fetch-retry';
@@ -218,8 +219,20 @@ const generateCdnModuleStructure = async (options) => {
     }
 };
 
+const cleanupOldGeneratedVersionedFolders = async (options) => {
+    const items = await fs.readdir(options.cdnpath);
+    // $FlowFixMe incompatible-call
+    const previousVersionedDirectories = items.filter(valid);
+
+    for (const directory of previousVersionedDirectories) {
+        await remove(join(options.cdnpath, directory));
+    }
+};
+
 const cdnifyGenerate = async (options) => {
     const shouldUseVersionedFolder = options['experimental-versioned-cdn'];
+
+    await cleanupOldGeneratedVersionedFolders(options);
 
     await generateCdnModuleStructure({
         ...options,


### PR DESCRIPTION
this will remove previously generated versioned folders created with the `--experimental-versioned-cdn` flag before creating a new one.

Because we have git history, we don't need to keep each versioned folder in the latest commit of the release repo. This would eventually get too big for git and for uploading assets to the CDNX tool