### PR TITLE
feat: reset feature branch after publishing an alpha release

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -64,7 +64,7 @@ const getCommitCount = async () => {
   const branchJSONData = await branchData.json();
 
   if (branchJSONData?.message === "Not Found") {
-    throw new Error("Branch not found via the GitHub Repos API.");
+    throw new Error("Branch not found via the GitHub Branches API.");
   }
 
   const { total_commits } = branchJSONData;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -72,7 +72,7 @@ const getCommitCount = async () => {
   return total_commits;
 };
 
-const commitCount = await getCommitCount();
+const startCommitCount = await getCommitCount();
 const UID = crypto.randomBytes(4).toString("hex");
 
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
@@ -133,7 +133,12 @@ if (DRY_RUN) {
 
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    await $`git reset --hard ${CURRENT_BRANCH}~${commitCount}`;
-    await $`git push --force-with-lease`;
+    const endCommitCount = await getCommitCount();
+    const commitDelta = endCommitCount - startCommitCount;
+
+    if (commitDelta > 0) {
+      await $`git reset --hard ${CURRENT_BRANCH}~${commitDelta}`;
+      await $`git push --force-with-lease`;
+    }
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,9 +48,6 @@ if (forked) {
 await $`grabthar-validate-git`;
 await $`grabthar-validate-npm`;
 
-let { stdout: startCommitCount } = await $`git rev-list --count HEAD`;
-startCommitCount = startCommitCount.trim();
-
 // This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
 let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
@@ -58,6 +55,10 @@ CURRENT_BRANCH = CURRENT_BRANCH.trim();
 let { stdout: DEFAULT_BRANCH } =
   await $`git remote show origin | sed -n '/HEAD branch/s/.*: //p'`;
 DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
+
+let { stdout: startCommitCount } =
+  await $`git rev-list --count ${CURRENT_BRANCH}`;
+startCommitCount = startCommitCount.trim();
 
 const UID = crypto.randomBytes(4).toString("hex");
 
@@ -119,7 +120,8 @@ if (DRY_RUN) {
 
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    let { stdout: endCommitCount } = await $`git rev-list --count HEAD`;
+    let { stdout: endCommitCount } =
+      await $`git rev-list --count ${CURRENT_BRANCH}`;
     endCommitCount = endCommitCount.trim();
 
     const commitDelta = endCommitCount - startCommitCount;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -57,7 +57,7 @@ let { stdout: DEFAULT_BRANCH } =
 DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
 
 let { stdout: startCommitCount } =
-  await $`git rev-list --count ${CURRENT_BRANCH}`;
+  await $`git rev-list --count ${CURRENT_BRANCH} ^${DEFAULT_BRANCH}`;
 startCommitCount = startCommitCount.trim();
 
 const UID = crypto.randomBytes(4).toString("hex");
@@ -121,7 +121,7 @@ if (DRY_RUN) {
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
     let { stdout: endCommitCount } =
-      await $`git rev-list --count ${CURRENT_BRANCH}`;
+      await $`git rev-list --count ${CURRENT_BRANCH} ^${DEFAULT_BRANCH}`;
     endCommitCount = endCommitCount.trim();
 
     const commitDelta = endCommitCount - startCommitCount;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,7 +48,8 @@ if (forked) {
 await $`grabthar-validate-git`;
 await $`grabthar-validate-npm`;
 
-const startCommitCount = await $`git rev-list --count HEAD`;
+let { stdout: startCommitCount } = await $`git rev-list --count HEAD`;
+startCommitCount = startCommitCount.trim();
 
 // This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
@@ -118,7 +119,9 @@ if (DRY_RUN) {
 
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    const endCommitCount = await $`git rev-list --count HEAD`;
+    let { stdout: endCommitCount } = await $`git rev-list --count HEAD`;
+    endCommitCount = endCommitCount.trim();
+
     const commitDelta = endCommitCount - startCommitCount;
 
     if (commitDelta > 0) {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,9 +48,10 @@ if (forked) {
 await $`grabthar-validate-git`;
 await $`grabthar-validate-npm`;
 
+const startCommitCount = await $`git rev-list --count HEAD`;
+
 // This will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
 
-const startCommitCount = await $`git rev-list --count HEAD`;
 let { stdout: CURRENT_BRANCH } = await $`git rev-parse --abbrev-ref HEAD`;
 CURRENT_BRANCH = CURRENT_BRANCH.trim();
 let { stdout: DEFAULT_BRANCH } =
@@ -115,10 +116,11 @@ if (DRY_RUN) {
     await $`grabthar-activate --LOCAL_VERSION=${LOCAL_VERSION} --CDNIFY=false --ENVS=test,local,stage`;
   }
 
-  // reset feature branch after publishing alpha release
+  // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    const endCommitCount = $`git rev-list --count HEAD`;
+    const endCommitCount = await $`git rev-list --count HEAD`;
     const commitDelta = endCommitCount - startCommitCount;
+
     if (commitDelta > 0) {
       await $`git reset --hard HEAD~${commitDelta}`;
       await $`git push --force-with-lease`;

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -116,7 +116,7 @@ if (DRY_RUN) {
 
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    await $`git reset --hard HEAD~3`;
+    await $`git reset --hard ${CURRENT_BRANCH}~3`;
     await $`git push --force-with-lease`;
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -56,10 +56,6 @@ let { stdout: DEFAULT_BRANCH } =
   await $`git remote show origin | sed -n '/HEAD branch/s/.*: //p'`;
 DEFAULT_BRANCH = DEFAULT_BRANCH.trim();
 
-let { stdout: startCommitCount } =
-  await $`git rev-list --count ${CURRENT_BRANCH} ^${DEFAULT_BRANCH}`;
-startCommitCount = startCommitCount.trim();
-
 const UID = crypto.randomBytes(4).toString("hex");
 
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
@@ -120,15 +116,7 @@ if (DRY_RUN) {
 
   // reset feature branch after publishing an alpha release
   if (DIST_TAG === "alpha") {
-    let { stdout: endCommitCount } =
-      await $`git rev-list --count ${CURRENT_BRANCH} ^${DEFAULT_BRANCH}`;
-    endCommitCount = endCommitCount.trim();
-
-    const commitDelta = endCommitCount - startCommitCount;
-
-    if (commitDelta > 0) {
-      await $`git reset --hard HEAD~${commitDelta}`;
-      await $`git push --force-with-lease`;
-    }
+    await $`git reset --hard HEAD~3`;
+    await $`git push --force-with-lease`;
   }
 }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -72,12 +72,13 @@ const getCommitCount = async () => {
   return total_commits;
 };
 
-const startCommitCount = await getCommitCount();
 const UID = crypto.randomBytes(4).toString("hex");
+let startCommitCount;
 
 if (CURRENT_BRANCH !== DEFAULT_BRANCH) {
   BUMP = "prerelease";
   DIST_TAG = "alpha";
+  startCommitCount = await getCommitCount();
   await $`npm ${noGitTag} version ${BUMP} --preid=${DIST_TAG}-${UID}`;
 } else {
   await $`npm ${noGitTag} version ${BUMP}`;


### PR DESCRIPTION
### Purpose

While publishing an alpha release from a feature branch, new commits are pushed to the feature branch, which ~~messes up~~ soils any open PR's (example screenshots below). This PR resets the feature branch after publishing to npm.

### Screenshots

An open PR before publishing an alpha release:

![Before publishing](https://user-images.githubusercontent.com/20399044/210847509-2ebe4c67-ceae-413f-9d29-ec7831d02c6e.png)

An open PR after publishing an alpha release:

![After publishing](https://user-images.githubusercontent.com/20399044/210847527-f8133b36-60ed-45fe-bf1f-d1ca178686f9.png)
