### PR TITLE
fix: fix tarball guard case

### DIFF
--- a/scripts/cdnify.js
+++ b/scripts/cdnify.js
@@ -237,7 +237,7 @@ const cdnifyGenerateModule = async (
 
   const tarball = versionInfo.dist && versionInfo.dist.tarball;
 
-  if (!versionInfo) {
+  if (!tarball) {
     throw new Error(`NPM info for ${name}@${version} has no tarball`);
   }
 


### PR DESCRIPTION
Looks like this conditional should be checking the truthiness of `tarball`, not `versionInfo`