### PR TITLE
feat: upgrade node-cli to remove ip module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "inquirer": "^7.3.2",
     "libnpmconfig": "^1.2.1",
     "node-fetch": "^2.6.0",
-    "npm": "^6.14.0",
+    "npm": "^9.0.0",
     "parse-diff": "^0.8.1",
     "semver": "^7.3.5",
     "shelljs": "^0.8.4",


### PR DESCRIPTION
### Why is this change required?

[LI-54311](https://paypal.atlassian.net/browse/LI-54311)

A vulnerability was found in the ip package version 1.1.8. The goal of this PR is to upgrade npm-cli package removing the IP module  dependency

Before this PR

<img width="729" alt="Screenshot 2025-02-03 at 19 35 27" src="https://github.com/user-attachments/assets/0067e45e-7e0b-44f1-a467-f147918d41b6" />

After this PR

<img width="689" alt="Screenshot 2025-02-03 at 19 32 03" src="https://github.com/user-attachments/assets/a3d43238-900d-46ae-b5c3-f82f63adf7e4" />

