### PR TITLE
Chore: update npm config registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jest": "jest",
     "test": "npm run format:check && npm run lint && npm run flow && npm run jest",
     "babel": "babel scripts --ignore=node_modules,scripts/*.mjs --out-dir scripts --source-maps inline",
-    "postinstall": "npm_config_registry=https://npm.paypal.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
+    "postinstall": "npm_config_registry=https://npm.dev.paypalinc.com npm install @paypalcorp/web --no-save --proxy='null' --https-proxy='null' || echo 'Unable to install cdnx cli tools'",
     "prepare": "husky install",
     "prepublishOnly": "npm run babel",
     "release": "standard-version",


### PR DESCRIPTION
This is blocking dependancies using this package due to the [postinstall](https://github.com/krakenjs/grabthar-release/blob/main/package.json#L15C21-L15C179) command using a deprecated npm config registry url.

https://npm.paypal.com/ is [officially deprecated](https://github.paypal.com/pages/webplatformengineering/docs/announcements/2023/10/25/new-npm-registry/) and throws errors.

