### PR TITLE
feat: add --REJECT flag to grabthar-upgrade

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -6,7 +6,7 @@ import { createRequire } from "module";
 
 import { $, argv } from "zx";
 
-const { MODULE } = argv;
+const { MODULE, REJECT } = argv;
 const CWD = cwd();
 const moduleMetaUrl = import.meta.url;
 const require = createRequire(moduleMetaUrl);
@@ -16,11 +16,15 @@ const { EXPERIMENTAL_DEPENDENCY_TEST } = env;
 
 await $`grabthar-validate-git`;
 
-if (!MODULE) {
-  await $`npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade`;
-} else {
-  await $`npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade --filter=${MODULE}`;
+const extraArgs = [];
+if (MODULE) {
+  extraArgs.push(`--filter=${MODULE}`);
 }
+if (REJECT) {
+  extraArgs.push(`--reject=${REJECT}`);
+}
+
+await $`npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade ${extraArgs}`;
 
 await $`rm -rf ./node_modules`;
 await $`rm -f ./package-lock.json`;


### PR DESCRIPTION
## Summary
- Adds optional `--REJECT` flag to `grabthar-upgrade` that forwards to `npm-check-updates --reject`
- Allows consumers to exclude specific packages from being upgraded (e.g. `npm run upgrade -- --REJECT="@scope/package"`)
- Fully backward-compatible, no behavior change when `--REJECT` is not passed

## Motivation
Allows repos to pin specific dependency versions while still running automated upgrades for everything else.

## Test
```
$ node /Users/nroman/dev/public/grabthar-release/scripts/upgrade.mjs --REJECT="@krakenjs/zoid"
$ npx npm-check-updates --registry='http://registry.npmjs.org' --dep=prod --upgrade $'--reject=@krakenjs/zoid'
Upgrading /Users/nroman/dev/public/paypal-sdk-release/package.json

 @paypal/checkout-components   5.0.41  →  5.0.412
 @paypal/common-components     1.0.40  →   1.0.57
 @paypal/sdk-client           4.0.200  →  4.0.204
```

zoid stays pinned at 10.5.0 while all other dependencies upgrade as expected.