### PR TITLE
fix: update npm publish token secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Publish to npm
         run: npm run release
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.KRAKENJS_PAYPAL_SDK_NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
Update publish workflow to use the correct npm token secret (`KRAKENJS_PAYPAL_SDK_NPM_AUTH_TOKEN`), matching the pattern used in other krakenjs repos (e.g. zoid).